### PR TITLE
Add support for overriding "flags" config via URL

### DIFF
--- a/src/utils/config/README.md
+++ b/src/utils/config/README.md
@@ -1,6 +1,9 @@
-# Overview
+# Configuration
+
+## Overview
 
 The configuration has three levels and will be loaded in this sequence:
+
 - Configuration in file `src/config.json`
 - `<body>` attribute overrides that comes from env variables in production
 build. `public/index.html`
@@ -9,7 +12,7 @@ build. `public/index.html`
 One important aspect is to know that configuration values are only set if the
 provided value is defined, if not it will simply keep the old value.
 
-## Configuration File
+### Configuration File
 
 Example `src/config.json` extract:
 
@@ -17,7 +20,8 @@ Example `src/config.json` extract:
     "clusterEnvironment": "dev",
     "clusterName": "playground-master-45"
 
-## Body Attributes
+### Body Attributes
+
 These are set via the `run_nginx.sh` in production runs. There are templates that
 will be replaced with environment variables.
 
@@ -31,22 +35,29 @@ Becomes:
 
 Note that on some systems these names are case sensitive.
 
-## URL Search Parameters
+### URL Search Parameters
+
+URL parameter values **must** be valid JSON, e.g. `"qa"` instead of `qa`.
+
 Supported URL Search Parameters:
+
 - radixClusterName
 - radixClusterBase
-- radixApiEnvironment
+- radixClusterType
+- radixEnvironment
+- flags
 
 Example:
 
-    https://website.com/route?radixApiEnvironment=dev&radixClusterName=release-1&radixClusterBase=cluster.radix.equinor.com
+    https://website.com/route?radixApiEnvironment="dev"&radixClusterName="release-1"&radixClusterBase="cluster.radix.equinor.com"
 
 To remove the config set via URL; simply clear the search parameters and then
 request the page again.
 
-# Code
+## Code
 
-## Location
+### Location
+
 The entry point for the configuration with the application specific values is
 located in `/src/utils/config/index.js`. This is the file you import to read the
 configuration.
@@ -55,14 +66,17 @@ If you want to change the way it works, you can open it and check out the
 supporting handlers, that handle the different methods of setting the
 configuration.
 
-## Using
+### Using
+
 To use the configuration, you can use it like so:
 
     import configHandler from 'utils/config';
     const domain = configHandler.getDomain();
 
-## Handlers
+### Handlers
+
 Currently there are three handlers:
+
 - `BodyHandler` loading from BODY tag in HTML.
 - `ObjectHandler` loading from Object in code, like from a JSON file.
 - `URLSearchParamsHandler` loading config from URL.

--- a/src/utils/config/urlSearchParamsHandler.js
+++ b/src/utils/config/urlSearchParamsHandler.js
@@ -31,12 +31,21 @@ export default class URLSearchParamsHandler {
    * Load value from search params by name and then set it to the provided
    * config key if there was a value.
    *
-   * @param {string} searchParamsName Search param name.
+   * @param {string} paramName Search param name.
    * @param {string} configKey Config key name.
    */
-  loadAndSetKey(searchParamsName, configKey) {
-    if (this.searchParams.has(searchParamsName)) {
-      this.setConfig(configKey, this.searchParams.get(searchParamsName));
+  loadAndSetKey(paramName, configKey) {
+    if (this.searchParams.has(paramName)) {
+      let parsedParamValue;
+      try {
+        parsedParamValue = JSON.parse(this.searchParams.get(paramName));
+      } catch (e) {
+        console.warn(
+          `Cannot parse value for URL param "${paramName}" as JSON; ignoring`
+        );
+        return;
+      }
+      this.setConfig(configKey, parsedParamValue);
     }
   }
 
@@ -61,5 +70,6 @@ export default class URLSearchParamsHandler {
     this.loadAndSetKey('radixClusterBase', configKeys.keys.RADIX_CLUSTER_BASE);
     this.loadAndSetKey('radixClusterType', configKeys.keys.RADIX_CLUSTER_TYPE);
     this.loadAndSetKey('radixEnvironment', configKeys.keys.RADIX_ENVIRONMENT);
+    this.loadAndSetKey('flags', configKeys.keys.FLAGS);
   }
 }

--- a/src/utils/config/urlSearchParamsHandler.test.js
+++ b/src/utils/config/urlSearchParamsHandler.test.js
@@ -27,7 +27,7 @@ describe('loadKeys', () => {
 
     // create a url to parse
     const url = new URL(
-      'https://website.com/route?radixApiEnvironment=dev&radixClusterName=release-1&radixClusterBase=cluster.radix.equinor.com'
+      'https://website.com/route?radixApiEnvironment="dev"&radixClusterName="release-1"&radixClusterBase="cluster.radix.equinor.com"'
     );
 
     const handler = new URLSearchParamsHandler(setConfigFake, url.searchParams);
@@ -54,7 +54,9 @@ describe('loadKeys', () => {
     };
 
     // create a url to parse
-    const url = new URL('https://website.com/route?radixClusterName=release-1');
+    const url = new URL(
+      'https://website.com/route?radixClusterName="release-1"'
+    );
 
     const handler = new URLSearchParamsHandler(setConfigFake, url.searchParams);
     handler.loadKeys();


### PR DESCRIPTION
This adds the ability to override the `flags` configuration by using the `?flags=…` URL parameter. By necessity, all "config override" URL parameters must now be valid JSON.