### PR TITLE
Update to oauth2-proxy v7.2.0

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -31,7 +31,7 @@ spec:
       secrets:
         - DYNATRACE_API_TOKEN # Token to use for display of availability metrics
     - name: auth
-      image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3 # see https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/docs/configuration/overview.md
+      image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.0 # see https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/docs/configuration/overview.md
       ports:
         - name: http
           port: 8000


### PR DESCRIPTION
7.2.0 fixes a bug <=7.1.3 where session cookie is not updated