### PR TITLE
increase memory for auth component

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -43,10 +43,10 @@ spec:
       publicPort: http
       resources:
         requests:
-          memory: "50Mi"
+          memory: "100Mi"
           cpu: "25m"
         limits:
-          memory: "50Mi"
+          memory: "200Mi"
           cpu: "1000m"
       secrets:
         - OAUTH2_PROXY_CLIENT_ID # ID of the "Web Console" AD app. This is a secret so it can be configured per cluster, but it's not sensitive info

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -44,10 +44,10 @@ spec:
       resources:
         requests:
           memory: "100Mi"
-          cpu: "25m"
+          cpu: "100m"
         limits:
-          memory: "200Mi"
-          cpu: "1000m"
+          memory: "100Mi"
+          cpu: "100m"
       secrets:
         - OAUTH2_PROXY_CLIENT_ID # ID of the "Web Console" AD app. This is a secret so it can be configured per cluster, but it's not sensitive info
         - OAUTH2_PROXY_CLIENT_SECRET # Azure client secret for "Web Console frontend app" in the "Web Console" AD app for the appropriate cluster


### PR DESCRIPTION
The auth component exceeds the memory limit a few times per day and is OOM killed.