### PR TITLE
753 set ci lookup default limit zero

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm run deps
 RUN CI=true npm run test
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:1.23-alpine
+FROM nginxinc/nginx-unprivileged:1.24-alpine
 WORKDIR /app
 COPY --from=builder /app/build /app
 COPY proxy/server.conf /default.conf

--- a/docker-compose-host-macos.yml
+++ b/docker-compose-host-macos.yml
@@ -30,7 +30,7 @@ services:
       test: "exit 0"
 
   proxy:
-    image: nginxinc/nginx-unprivileged:1.23-alpine
+    image: nginxinc/nginx-unprivileged:1.24-alpine
     container_name: radix-proxy_container
     depends_on:
       web:

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -20,7 +20,7 @@ services:
       - "9222:9222"
 
   proxy:
-    image: nginxinc/nginx-unprivileged:1.23-alpine
+    image: nginxinc/nginx-unprivileged:1.24-alpine
     container_name: radix-proxy_container
     environment:
       - DYNATRACE_API_TOKEN=${DYNATRACE_API_TOKEN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "9222:9222"
 
   proxy:
-    image: nginxinc/nginx-unprivileged:1.23-alpine
+    image: nginxinc/nginx-unprivileged:1.24-alpine
     container_name: radix-proxy_container
     environment:
       - DYNATRACE_API_TOKEN=${DYNATRACE_API_TOKEN}

--- a/src/api/service-now-api.ts
+++ b/src/api/service-now-api.ts
@@ -8,7 +8,7 @@ import { arrayNormalizer } from '../models/model-utils';
 export class ServiceNowApi extends BaseAxiosApi {
   async getApplications(
     name: string = '',
-    limit: number = 25
+    limit: number = 0
   ): Promise<Array<ServiceNowApplicationModel>> {
     const params = new URLSearchParams();
     if (name) {


### PR DESCRIPTION
- Change default limit for CI lookup to zero (meaning "get all")
- Upgrade from nginx 1.23 to 1.24