### PR TITLE
disable close external DNS scrim on click outside

### DIFF
--- a/src/components/page-active-component/external-dns.tsx
+++ b/src/components/page-active-component/external-dns.tsx
@@ -156,7 +156,6 @@ export const ExternalDNSAccordion: FunctionComponent<{
           className="secret-item__scrim"
           title={selectedExternalDns.fqdn}
           open={visibleScrim}
-          isDismissable
           onClose={() => {
             setVisibleScrim(false);
           }}


### PR DESCRIPTION
Prevent external DNS popup (for setting cert and key) from closing when clicking outside the form