### PR TITLE
ignore external dns alias click when using automation

### DIFF
--- a/src/components/page-active-component/external-dns.tsx
+++ b/src/components/page-active-component/external-dns.tsx
@@ -143,6 +143,9 @@ export const ExternalDNSAccordion: FunctionComponent<{
               <ExternalDNSList
                 externalDnsList={externalDNSList}
                 onItemClick={(v) => {
+                  if (v.tls.useAutomation) {
+                    return;
+                  }
                   setSelectedExternalDns(v);
                   setVisibleScrim(true);
                 }}


### PR DESCRIPTION
Fixed a bug where it was possible to click and open the "set cert and key" for an external DNS alias with automation enabled.