### PR TITLE
Fix broken link and non-react-router navigation

### DIFF
--- a/src/components/data-chart/index.tsx
+++ b/src/components/data-chart/index.tsx
@@ -28,6 +28,7 @@ import {
   useLazyGetStatusItemsQuery,
 } from '../../store/dynatrace-api';
 import { isNull } from 'lodash';
+import { externalUrls } from '../../externalUrls';
 
 type GetStatusItemsFunction = ReturnType<typeof useLazyGetStatusItemsQuery>[0];
 
@@ -341,7 +342,7 @@ export const AvailabilityCharts: FunctionComponent = () => {
             For more information on availability, please check the{' '}
             <Typography
               link
-              href="https://radix.equinor.com/docs/topic-uptime/"
+              href={externalUrls.uptimeDocs}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/global-top-nav/index.tsx
+++ b/src/components/global-top-nav/index.tsx
@@ -1,4 +1,10 @@
-import { Button, Icon, Tabs, TopBar } from '@equinor/eds-core-react';
+import {
+  Button,
+  Icon,
+  Tabs,
+  TopBar,
+  Typography,
+} from '@equinor/eds-core-react';
 import { close, info_circle, menu } from '@equinor/eds-icons';
 import { clsx } from 'clsx';
 import {
@@ -17,6 +23,7 @@ import { routes } from '../../routes';
 import { configVariables } from '../../utils/config';
 
 import './style.css';
+import { Link } from 'react-router-dom';
 
 interface TabItemTemplateProps {
   href: string;
@@ -35,9 +42,17 @@ const TabItemTemplate = forwardRef<
 ));
 
 const AboutButton: FunctionComponent = () => (
-  <Button variant="ghost_icon" href={routes.about}>
+  <Typography
+    link
+    as={Link}
+    to={routes.about}
+    token={{
+      color: 'var(--eds_interactive_primary__resting)',
+      textDecoration: 'none',
+    }}
+  >
     <Icon data={info_circle} />
-  </Button>
+  </Typography>
 );
 
 export const GlobalTopNav: FunctionComponent = () => {

--- a/src/components/page-active-component/overview.tsx
+++ b/src/components/page-active-component/overview.tsx
@@ -21,6 +21,7 @@ import {
 import './style.css';
 import { DNSAliases } from './dns-aliases';
 import { ResourceRequirements } from '../resource-requirements';
+import { externalUrls } from '../../externalUrls';
 
 const URL_VAR_NAME = 'RADIX_PUBLIC_DOMAIN_NAME';
 
@@ -54,7 +55,7 @@ export const Overview: FunctionComponent<{
           the component to <code>0</code> in{' '}
           <Typography
             link
-            href="https://radix.equinor.com/references/reference-radix-config/#replicas"
+            href={new URL('#replicas', externalUrls.referenceRadixConfig)}
           >
             radixconfig.yaml
           </Typography>

--- a/src/externalUrls.ts
+++ b/src/externalUrls.ts
@@ -14,6 +14,7 @@ export const externalUrls = {
   alertingGuide: 'https://www.radix.equinor.com/guides/alerting/',
   externalDNSGuide: 'https://www.radix.equinor.com/guides/external-alias/',
   workloadIdentityGuide: 'https://www.radix.equinor.com/guides/workload-identity/',
+  uptimeDocs: 'https://radix.equinor.com/docs/topic-uptime/',
   radixPlatformWebConsole: `https://console.${clusterBases.radixPlatformWebConsole}/`,
   radixPlatform2WebConsole: `https://console.${clusterBases.radixPlatform2WebConsole}/`,
   playgroundWebConsole: `https://console.${clusterBases.playgroundWebConsole}/`,


### PR DESCRIPTION
- fixed broken link to radix-config docs
- Change navigation to "about" page to use reaft-router