### PR TITLE
Fixed pipeline env selector

### DIFF
--- a/src/components/create-job-form/pipeline-form-build-branches.tsx
+++ b/src/components/create-job-form/pipeline-form-build-branches.tsx
@@ -58,7 +58,6 @@ export function PipelineFormBuildBranches({
           .flatMap(([, commits]) => commits)
       )
     );
-    console.log(values);
     setFilteredBranches(values);
   };
   const handleChange = ({

--- a/src/components/create-job-form/pipeline-form-build-branches.tsx
+++ b/src/components/create-job-form/pipeline-form-build-branches.tsx
@@ -34,12 +34,32 @@ export function PipelineFormBuildBranches({
   const [branchFullName, setBranchFullName] = useState('');
   const [toEnvironment, setToEnvironment] = useState('');
   const branches = useGetApplicationBranches(appName);
+  const [filteredBranches, setFilteredBranches] = useState([]);
 
   const handleOnTextChange = ({
     target: { value },
   }: ChangeEvent<HTMLInputElement>) => {
     setBranch(value);
     setBranchFullName(value);
+    setToEnvironment('');
+    const cleanRegex = (val: string): string => {
+      switch (val) {
+        case '*':
+          return '.+';
+        case '':
+          return '^$';
+      }
+      return val;
+    };
+    const values = Array.from(
+      new Set(
+        Object.entries(branches)
+          .filter(([key]) => new RegExp(cleanRegex(key)).test(value))
+          .flatMap(([, commits]) => commits)
+      )
+    );
+    console.log(values);
+    setFilteredBranches(values);
   };
   const handleChange = ({
     target: { value },
@@ -57,7 +77,7 @@ export function PipelineFormBuildBranches({
         appName,
         pipelineParametersBuild: { branch, toEnvironment },
       };
-      let jobName = '';
+      let jobName: string;
       if (pipelineName === 'build-deploy') {
         jobName = (await triggerBuildDeploy(body).unwrap()).name;
       } else {
@@ -122,42 +142,43 @@ export function PipelineFormBuildBranches({
               </fieldset>
             </>
           )}
-          {selectedBranch && branches[selectedBranch]?.length > 1 && (
-            <div className="grid grid--gap-small input">
-              <Typography
-                group="input"
-                variant="text"
-                token={{ color: 'currentColor' }}
-              >
-                Environment (optional)
-              </Typography>
-              <NativeSelect
-                id="ToEnvironmentSelect"
-                label=""
-                name="toEnvironment"
-                onChange={(e) => setToEnvironment(e.target.value)}
-                value={toEnvironment}
-              >
-                <option value="">
-                  All environments build from the branch{' '}
-                  {branch ?? selectedBranch}
-                </option>
-                {branches[selectedBranch]?.map((envName) => (
-                  <option key={envName} value={envName}>
-                    {envName}
+          {!isAnyValidRegex(branch) &&
+            branch &&
+            filteredBranches?.length > 0 && (
+              <div className="grid grid--gap-small input">
+                <Typography
+                  group="input"
+                  variant="text"
+                  token={{ color: 'currentColor' }}
+                >
+                  Environment (optional)
+                </Typography>
+                <NativeSelect
+                  id="ToEnvironmentSelect"
+                  label=""
+                  name="toEnvironment"
+                  onChange={(e) => setToEnvironment(e.target.value)}
+                  value={toEnvironment}
+                >
+                  <option value="">
+                    All environments build from the branch {branch}
                   </option>
-                ))}
-              </NativeSelect>
-            </div>
-          )}
-          {pipelineName === 'build-deploy' && branches && selectedBranch && (
-            <TargetEnvs
-              targetEnvs={
-                toEnvironment ? [toEnvironment] : branches[selectedBranch]
-              }
-              branch={branch}
-            />
-          )}
+                  {filteredBranches?.map((envName) => (
+                    <option key={envName} value={envName}>
+                      {envName}
+                    </option>
+                  ))}
+                </NativeSelect>
+              </div>
+            )}
+          {pipelineName === 'build-deploy' &&
+            branch &&
+            !isAnyValidRegex(branch) && (
+              <TargetEnvs
+                targetEnvs={toEnvironment ? [toEnvironment] : filteredBranches}
+                branch={branch}
+              />
+            )}
         </div>
 
         <div className="o-action-bar">
@@ -172,7 +193,10 @@ export function PipelineFormBuildBranches({
             </Alert>
           )}
           <div>
-            <Button disabled={!isValidBranchName(branch)} type="submit">
+            <Button
+              disabled={!isValidBranchName(branch) || isAnyValidRegex(branch)}
+              type="submit"
+            >
               Create job
             </Button>
           </div>


### PR DESCRIPTION
It can be tested on [such config (in radix-mini-app)](https://github.com/satr/radix-mini-app/blob/main/radixconfig-buildah.yaml)
```
  environments:
  - name: dev
    build:
      from: mai.
  - name: dev3
    build:
      from: rel.?ase
  - name: dev4
    build:
      from: rel.ase
  - name: dev6
    build:
      from: "v\\d+\\.\\d+\\.\\d+"
  - name: dev7
    build:
      from: "^test-radix-."
  - name: dev8
    build:
      from: main
  - name: dev10
  - name: dev11
    build:
      from: main
  - name: dev20
    build:
      from: "*"
  - name: dev21
    build:
      from: ".*"
  - name: dev30
    build:
      from: ma.*
  - name: dev31
    build:
      from: ma.*
  - name: dev32
    build:
      from: ma.+

```