### PR TITLE
Fix typo in Restart OAuth2 Service toast (#1161)

### DIFF
--- a/src/components/page-active-component/oauth-toolbar.tsx
+++ b/src/components/page-active-component/oauth-toolbar.tsx
@@ -34,7 +34,7 @@ export function OAuthToolbar({
       await trigger({ appName, envName, componentName }).unwrap();
       startRefetch();
     },
-    'Restaring OAuth2 Service',
+    'Restarting OAuth2 Service',
     'Failed to restart Oauth2 Service'
   );
   return (


### PR DESCRIPTION
This PR fixes typo in Restart OAuth2 Service toast

![image](https://github.com/user-attachments/assets/973e611b-9dd6-404d-9d72-bee4bbf899fc)

Fixes #1161  