### PR TITLE
fix: disable client cache of index html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN chown -R nginx /etc/nginx/conf.d \
     && chown -R nginx /app \
     && chmod +x run_nginx.sh
 USER 101
-CMD /bin/sh -c ". run_nginx.sh"
+CMD ["/bin/sh", "-c", ". run_nginx.sh"]

--- a/index.html
+++ b/index.html
@@ -45,7 +45,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no" />
-
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=1h7zOvlFSE">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=1h7zOvlFSE">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=1h7zOvlFSE">


### PR DESCRIPTION
Disable client side caching of index.html to prevent the auth 302 redirect to be performed randomly from resources (css, js, images etc) referenced in the main page. This should hopefully trigger 302 when loading the main page, and when loading resources.