### PR TITLE
fix: Show BuildKit status as used/unknown/unused

### DIFF
--- a/src/components/job-overview/index.tsx
+++ b/src/components/job-overview/index.tsx
@@ -255,7 +255,10 @@ export const JobOverview = ({ appName, jobName }: Props) => {
                     {(job.pipeline === 'build-deploy' || job.pipeline === 'build') && (
                       <>
                         <Typography>
-                          Build Kit <strong>{job.useBuildKit === true ? 'used' : 'not used'}</strong>
+                          Build Kit{' '}
+                          <strong>
+                            {job.useBuildKit == null ? 'unknown' : job.useBuildKit === true ? 'used' : 'not used'}
+                          </strong>
                         </Typography>
                         {job.useBuildKit === true && buildCacheStatus.length > 0 && (
                           <Typography>


### PR DESCRIPTION
Enhance the display of Build Kit status by indicating whether it is used, not used, or unknown based on the job configuration.