### PR TITLE
Update API server URL configuration

### DIFF
--- a/proxy/server.conf
+++ b/proxy/server.conf
@@ -13,7 +13,7 @@ server {
 
     location /api/ {
         proxy_buffering off;
-        proxy_pass https://server-radix-api-${RADIX_ENVIRONMENT}.${RADIX_CLUSTERNAME}.${RADIX_DNS_ZONE};
+        proxy_pass https://api.${RADIX_CLUSTERNAME}.${RADIX_DNS_ZONE};
     }
 
     location /cost-api/ {

--- a/proxy/server.dev.conf
+++ b/proxy/server.dev.conf
@@ -10,7 +10,7 @@ server {
 
     location /api/ {
         proxy_buffering off;
-        # proxy_pass https://server-radix-api-qa.dev.radix.equinor.com;
+        # proxy_pass https://api.dev.radix.equinor.com;
         # proxy_pass http://<WSL_IP>:3002; #for localhost API on WSL
         proxy_pass http://host.docker.internal:3002; #for localhost API on MacOS https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
     }


### PR DESCRIPTION
Change the API requests to use the new format for the server URL, ensuring requests are sent to `api.<cluster>.<dns_zone>` instead of the previous format.