### PR TITLE
fix: Remove BuildKit references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.30.0.tgz",
       "integrity": "sha512-HBBKfbZkMVzzF5bofvS1cXuNHFVc+gt4/HOnCmG/0hsHuZRJvJvDg/+7nTwIpoqvJc8BQp5o23rBUfisOLxR+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.17.0"
       },
@@ -604,6 +605,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -652,31 +654,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1328,9 +1308,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1348,9 +1325,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1368,9 +1342,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1388,9 +1359,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1408,9 +1376,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1428,9 +1393,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1678,8 +1640,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1790,6 +1751,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
       "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1805,6 +1767,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1815,6 +1778,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2242,7 +2206,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3004,8 +2967,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4090,6 +4052,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4347,9 +4310,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4371,9 +4331,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4395,9 +4352,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4419,9 +4373,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4541,7 +4492,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5970,7 +5920,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5986,7 +5935,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5999,8 +5947,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6044,6 +5991,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6074,6 +6022,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6129,6 +6078,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6310,7 +6260,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6866,6 +6817,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -7114,6 +7066,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7276,6 +7229,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7473,6 +7427,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.30.0.tgz",
       "integrity": "sha512-HBBKfbZkMVzzF5bofvS1cXuNHFVc+gt4/HOnCmG/0hsHuZRJvJvDg/+7nTwIpoqvJc8BQp5o23rBUfisOLxR+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.17.0"
       },
@@ -605,7 +604,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -654,9 +652,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1640,7 +1660,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1751,7 +1772,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
       "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1767,7 +1787,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1778,7 +1797,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2206,6 +2224,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2967,7 +2986,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4052,7 +4072,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4492,6 +4511,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5920,6 +5940,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5935,6 +5956,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5947,7 +5969,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5991,7 +6014,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6022,7 +6044,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6078,7 +6099,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6260,8 +6280,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6817,7 +6836,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -7066,7 +7084,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7229,7 +7246,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7427,7 +7443,6 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/radixconfig.c2.yaml
+++ b/radixconfig.c2.yaml
@@ -3,8 +3,6 @@ kind: RadixApplication
 metadata:
   name: radix-web-console
 spec:
-  build:
-    useBuildKit: true
   dnsAlias:
     - alias: "console"
       component: web

--- a/radixconfig.c3.yaml
+++ b/radixconfig.c3.yaml
@@ -3,8 +3,6 @@ kind: RadixApplication
 metadata:
   name: radix-web-console
 spec:
-  build:
-    useBuildKit: true
   dnsAlias:
     - alias: "console"
       component: web

--- a/radixconfig.dev.yaml
+++ b/radixconfig.dev.yaml
@@ -3,8 +3,6 @@ kind: RadixApplication
 metadata:
   name: radix-web-console
 spec:
-  build:
-    useBuildKit: true
   dnsAlias:
     - alias: "console"
       component: web

--- a/radixconfig.platform.yaml
+++ b/radixconfig.platform.yaml
@@ -3,8 +3,6 @@ kind: RadixApplication
 metadata:
   name: radix-web-console
 spec:
-  build:
-    useBuildKit: true
   dnsAlias:
     - alias: "console"
       component: web

--- a/radixconfig.playground.yaml
+++ b/radixconfig.playground.yaml
@@ -3,8 +3,6 @@ kind: RadixApplication
 metadata:
   name: radix-web-console
 spec:
-  build:
-    useBuildKit: true
   dnsAlias:
     - alias: "console"
       component: web

--- a/radixconfig.tpl.yaml
+++ b/radixconfig.tpl.yaml
@@ -3,8 +3,6 @@ kind: RadixApplication
 metadata:
   name: radix-web-console
 spec:
-  build:
-    useBuildKit: true
   dnsAlias:
     - alias: "console"
       component: web

--- a/src/components/create-job-form/pipeline-form-build-branches.tsx
+++ b/src/components/create-job-form/pipeline-form-build-branches.tsx
@@ -28,8 +28,7 @@ export function PipelineFormBuildBranches({ onSuccess, application, pipelineName
   const branches = useGetApplicationBranches(application)
   const hasBranches = Object.keys(branches).length > 0
   const [filteredBranches, setFilteredBranches] = useState<string[]>([])
-  const useBuildCache = application.useBuildKit && application.useBuildCache
-  const [overrideUseBuildCache, setOverrideUseBuildCache] = useState<boolean>(useBuildCache)
+  const [overrideUseBuildCache, setOverrideUseBuildCache] = useState<boolean>(application.useBuildCache)
   const [refreshBuildCache, setRefreshBuildCache] = useState<boolean>(false)
   const branchSelectId = useId()
   const toEnvironmentSelect = useId()
@@ -79,13 +78,11 @@ export function PipelineFormBuildBranches({ onSuccess, application, pipelineName
 
     const pipelineParametersBuild: PipelineParametersBuild = {
       branch: buildBranch,
-      toEnvironment,
+      toEnvironment: toEnvironment,
+      refreshBuildCache: refreshBuildCache,
     }
-    if (application.useBuildKit) {
-      if (useBuildCache !== overrideUseBuildCache) {
-        pipelineParametersBuild.overrideUseBuildCache = overrideUseBuildCache
-      }
-      pipelineParametersBuild.refreshBuildCache = refreshBuildCache
+    if (application.useBuildCache !== overrideUseBuildCache) {
+      pipelineParametersBuild.overrideUseBuildCache = overrideUseBuildCache
     }
     const body = {
       appName: application.name,
@@ -192,27 +189,20 @@ export function PipelineFormBuildBranches({ onSuccess, application, pipelineName
             )}
           </>
         )}
-        {application.useBuildKit && (
-          <>
-            <Typography group="input" variant="text" token={{ color: 'currentColor' }}>
-              Build Kit enabled
-            </Typography>
-            <div className="checkbox-group">
-              <Checkbox
-                label="Use Build Cache"
-                name="overrideUseBuildCache"
-                checked={overrideUseBuildCache}
-                onChange={() => setOverrideUseBuildCache(!overrideUseBuildCache)}
-              />
-              <Checkbox
-                label="Refresh Build Cache"
-                name="refreshBuildCache"
-                checked={refreshBuildCache}
-                onChange={() => setRefreshBuildCache(!refreshBuildCache)}
-              />
-            </div>
-          </>
-        )}
+        <div className="checkbox-group">
+          <Checkbox
+            label="Use Build Cache"
+            name="overrideUseBuildCache"
+            checked={overrideUseBuildCache}
+            onChange={() => setOverrideUseBuildCache(!overrideUseBuildCache)}
+          />
+          <Checkbox
+            label="Refresh Build Cache"
+            name="refreshBuildCache"
+            checked={refreshBuildCache}
+            onChange={() => setRefreshBuildCache(!refreshBuildCache)}
+          />
+        </div>
         <div className="o-action-bar">
           {createJobState.isLoading && (
             <div>

--- a/src/components/environments-summary/dev.tsx
+++ b/src/components/environments-summary/dev.tsx
@@ -92,7 +92,6 @@ export default (
             application={{
               environments: x,
               userIsAdmin: true,
-              useBuildKit: false,
               useBuildCache: false,
               name: 'any-name',
               registration: {

--- a/src/components/job-overview/index.tsx
+++ b/src/components/job-overview/index.tsx
@@ -33,7 +33,7 @@ function getStopButtonText(status: Job['status']): string {
 }
 
 function getBuildCacheStatus(job: Job | undefined): string {
-  if (!job || job.useBuildKit !== true) {
+  if (!job) {
     return ''
   }
   const statuses = []
@@ -252,20 +252,10 @@ export const JobOverview = ({ appName, jobName }: Props) => {
                       Triggered {job.triggeredFromWebhook && <strong>from GitHub webhook</strong>} by{' '}
                       <strong>{job.triggeredBy || 'N/A'}</strong>
                     </Typography>
-                    {(job.pipeline === 'build-deploy' || job.pipeline === 'build') && (
-                      <>
-                        <Typography>
-                          Build Kit{' '}
-                          <strong>
-                            {job.useBuildKit == null ? 'unknown' : job.useBuildKit === true ? 'used' : 'not used'}
-                          </strong>
-                        </Typography>
-                        {job.useBuildKit === true && buildCacheStatus.length > 0 && (
-                          <Typography>
-                            Build Cache <strong>{buildCacheStatus}</strong>
-                          </Typography>
-                        )}
-                      </>
+                    {(job.pipeline === 'build-deploy' || job.pipeline === 'build') && buildCacheStatus.length > 0 && (
+                      <Typography>
+                        Build Cache <strong>{buildCacheStatus}</strong>
+                      </Typography>
                     )}
                     {(job.gitRef || job.branch || job.commitID) && (
                       <Typography>

--- a/src/pages/deployment/components/DeploymentSummary.tsx
+++ b/src/pages/deployment/components/DeploymentSummary.tsx
@@ -16,7 +16,7 @@ type Props = {
 }
 
 function getBuildCacheStatus(deployment: Deployment | undefined): string {
-  if (!deployment || deployment.useBuildKit !== true) {
+  if (!deployment) {
     return ''
   }
   const statuses = []
@@ -71,17 +71,10 @@ export const DeploymentSummary = ({ appName, deployment }: Props) => {
               </strong>
             </Typography>
           )}
-          {typeof deployment.useBuildKit === 'boolean' && (
-            <>
-              <Typography>
-                Build Kit <strong>{deployment.useBuildKit === true ? 'used' : 'not used'}</strong>
-              </Typography>
-              {deployment.useBuildKit === true && buildCacheStatus.length > 0 && (
-                <Typography>
-                  Build Cache <strong>{buildCacheStatus}</strong>
-                </Typography>
-              )}
-            </>
+          {buildCacheStatus.length > 0 && (
+            <Typography>
+              Build Cache <strong>{buildCacheStatus}</strong>
+            </Typography>
           )}
           {(deployment.gitRef || deployment.gitCommitHash) && (
             <Typography>

--- a/src/store/radix-api.ts
+++ b/src/store/radix-api.ts
@@ -2588,10 +2588,8 @@ export type Deployment = {
   status: "Reconciling" | "Ready" | "Failed" | "Inactive";
   /** StatusReason contains details when deployment status is Failed */
   statusReason?: string;
-  /** Defaults to true and requires useBuildKit to have an effect. */
+  /** Defaults to true. */
   useBuildCache?: boolean | null;
-  /** Enables BuildKit when building Dockerfile. */
-  useBuildKit?: boolean | null;
 };
 export type ComponentSummary = {
   /** CommitID the commit ID of the branch to build
@@ -2653,10 +2651,8 @@ export type DeploymentSummary = {
   status: "Reconciling" | "Ready" | "Failed" | "Inactive";
   /** StatusReason contains details when deployment status is Failed */
   statusReason?: string;
-  /** Defaults to true and requires useBuildKit to have an effect. */
+  /** Defaults to true. */
   useBuildCache?: boolean | null;
-  /** Enables BuildKit when building Dockerfile. */
-  useBuildKit?: boolean | null;
 };
 export type Secret = {
   /** Component name of the component having the secret */
@@ -2756,10 +2752,8 @@ export type JobSummary = {
   triggeredBy?: string;
   /** TriggeredFromWebhook If true, the job was triggered from a webhook */
   triggeredFromWebhook: boolean;
-  /** Defaults to true and requires useBuildKit to have an effect. */
+  /** Defaults to true. */
   useBuildCache?: boolean | null;
-  /** Enables BuildKit when building Dockerfile. */
-  useBuildKit?: boolean | null;
 };
 export type ApplicationSummary = {
   /** Environments List of environments for this application */
@@ -2862,10 +2856,8 @@ export type Application = {
   /** Name the name of the application */
   name: string;
   registration: ApplicationRegistration;
-  /** UseBuildCache if build cache is used for building the application. Applicable when UseBuildKit is true. Default is true. */
+  /** UseBuildCache if build cache is used for building the application. Defaults to true. */
   useBuildCache: boolean;
-  /** UseBuildKit if buildkit is used for building the application */
-  useBuildKit: boolean;
   /** UserIsAdmin if user is member of application's admin groups */
   userIsAdmin: boolean;
 };
@@ -3277,10 +3269,8 @@ export type Job = {
   triggeredBy?: string;
   /** TriggeredFromWebhook If true, the job was triggered from a webhook */
   triggeredFromWebhook: boolean;
-  /** Defaults to true and requires useBuildKit to have an effect. */
+  /** Defaults to true. */
   useBuildCache?: boolean | null;
-  /** Enables BuildKit when building Dockerfile. */
-  useBuildKit?: boolean | null;
 };
 export type PipelineRun = {
   /** Ended timestamp */


### PR DESCRIPTION
Eliminate all references to BuildKit in the application configuration and UI components, streamlining the deployment process. This change simplifies the codebase by removing unnecessary complexity related to BuildKit usage.