### PR TITLE
Migrate to OIDC native authentication

### DIFF
--- a/radixconfig.c2.yaml
+++ b/radixconfig.c2.yaml
@@ -45,7 +45,7 @@ spec:
           cpu: "100m"
           memory: "50Mi"
       variables:
-        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0/"
         SERVICENOW_PROXY_SCOPES: "1b4a22f1-d4a1-4b6a-81b2-fd936daf1786/Application.Read" # scopes must be separated by space
         RADIXAPI_SCOPES: "openid profile offline_access 6dae42f8-4368-4678-94ff-3960e28e3630/user.read email" # scopes must be separated by space
         CMDB_CI_URL: "https://equinor.service-now.com/selfservice?id=form&table=cmdb_ci_business_app&sys_id={CIID}"

--- a/radixconfig.c3.yaml
+++ b/radixconfig.c3.yaml
@@ -45,7 +45,7 @@ spec:
           cpu: "100m"
           memory: "50Mi"
       variables:
-        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0/"
         SERVICENOW_PROXY_SCOPES: "1b4a22f1-d4a1-4b6a-81b2-fd936daf1786/Application.Read" # scopes must be separated by space
         RADIXAPI_SCOPES: "openid profile offline_access 6dae42f8-4368-4678-94ff-3960e28e3630/user.read email" # scopes must be separated by space
         CMDB_CI_URL: "https://equinor.service-now.com/selfservice?id=form&table=cmdb_ci_business_app&sys_id={CIID}"

--- a/radixconfig.dev.yaml
+++ b/radixconfig.dev.yaml
@@ -45,7 +45,7 @@ spec:
           cpu: "100m"
           memory: "50Mi"
       variables:
-        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0/"
         SERVICENOW_PROXY_SCOPES: "1b4a22f1-d4a1-4b6a-81b2-fd936daf1786/Application.Read" # scopes must be separated by space
         RADIXAPI_SCOPES: "openid profile offline_access 6dae42f8-4368-4678-94ff-3960e28e3630/user.read email" # scopes must be separated by space
         CMDB_CI_URL: "https://equinor.service-now.com/selfservice?id=form&table=cmdb_ci_business_app&sys_id={CIID}"

--- a/radixconfig.platform.yaml
+++ b/radixconfig.platform.yaml
@@ -45,7 +45,7 @@ spec:
           cpu: "100m"
           memory: "50Mi"
       variables:
-        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0/"
         SERVICENOW_PROXY_SCOPES: "1b4a22f1-d4a1-4b6a-81b2-fd936daf1786/Application.Read" # scopes must be separated by space
         RADIXAPI_SCOPES: "openid profile offline_access 6dae42f8-4368-4678-94ff-3960e28e3630/user.read email" # scopes must be separated by space
         CMDB_CI_URL: "https://equinor.service-now.com/selfservice?id=form&table=cmdb_ci_business_app&sys_id={CIID}"

--- a/radixconfig.playground.yaml
+++ b/radixconfig.playground.yaml
@@ -45,7 +45,7 @@ spec:
           cpu: "100m"
           memory: "50Mi"
       variables:
-        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0/"
         SERVICENOW_PROXY_SCOPES: "1b4a22f1-d4a1-4b6a-81b2-fd936daf1786/Application.Read" # scopes must be separated by space
         RADIXAPI_SCOPES: "openid profile offline_access 6dae42f8-4368-4678-94ff-3960e28e3630/user.read email" # scopes must be separated by space
         CMDB_CI_URL: "https://equinor.service-now.com/selfservice?id=form&table=cmdb_ci_business_app&sys_id={CIID}"

--- a/radixconfig.tpl.yaml
+++ b/radixconfig.tpl.yaml
@@ -45,7 +45,7 @@ spec:
           cpu: "100m"
           memory: "50Mi"
       variables:
-        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+        OAUTH2_AUTHORITY: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0/"
         SERVICENOW_PROXY_SCOPES: "1b4a22f1-d4a1-4b6a-81b2-fd936daf1786/Application.Read" # scopes must be separated by space
         RADIXAPI_SCOPES: "openid profile offline_access 6dae42f8-4368-4678-94ff-3960e28e3630/user.read email" # scopes must be separated by space
         CMDB_CI_URL: "https://equinor.service-now.com/selfservice?id=form&table=cmdb_ci_business_app&sys_id={CIID}"

--- a/src/init/msal-config.ts
+++ b/src/init/msal-config.ts
@@ -1,10 +1,14 @@
-import type { Configuration } from '@azure/msal-browser'
+import { type Configuration, ProtocolMode, ServerResponseType } from '@azure/msal-browser'
 import { configVariables } from '../utils/config'
 
 export const msalConfig: Configuration = {
   auth: {
     clientId: configVariables.OAUTH2_CLIENT_ID,
     authority: configVariables.OAUTH2_AUTHORITY,
+    protocolMode: ProtocolMode.OIDC,
+    OIDCOptions: {
+      serverResponseType: ServerResponseType.QUERY,
+    },
     redirectUri: `${window.location.origin}/applications`,
   },
   cache: {

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -18,7 +18,7 @@ export const configVariables = {
   OAUTH2_CLIENT_ID: getVariable('OAUTH2_CLIENT_ID', '5687b237-eda3-4ec3-a2a1-023e85a2bd84'),
   OAUTH2_AUTHORITY: getVariable(
     'OAUTH2_AUTHORITY',
-    'https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0'
+    'https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0'
   ),
   RADIXAPI_SCOPES: getVariable(
     'RADIXAPI_SCOPES',


### PR DESCRIPTION
Transition to OpenID Connect (OIDC) for authentication by updating the authority URL and configuring the MSAL library for OIDC protocol mode. This change with modern authentication standards.