### PR TITLE
Add known authorities for MSAL OIDC configuration

### DIFF
--- a/src/components/msal-auth-context/msal-auth-provider.tsx
+++ b/src/components/msal-auth-context/msal-auth-provider.tsx
@@ -35,6 +35,7 @@ export function MsalAuthProvider({ children }: PropsWithChildren) {
       forceUpdate()
     }
   }, [activeAccount, dispatch])
+  
 
   const ctx = useMemo(() => {
     if (!activeAccount) {

--- a/src/components/msal-auth-context/msal-auth-provider.tsx
+++ b/src/components/msal-auth-context/msal-auth-provider.tsx
@@ -35,7 +35,6 @@ export function MsalAuthProvider({ children }: PropsWithChildren) {
       forceUpdate()
     }
   }, [activeAccount, dispatch])
-  
 
   const ctx = useMemo(() => {
     if (!activeAccount) {

--- a/src/init/msal-config.ts
+++ b/src/init/msal-config.ts
@@ -1,21 +1,11 @@
 import { type Configuration, ProtocolMode, ServerResponseType } from '@azure/msal-browser'
 import { configVariables } from '../utils/config'
 
-const authority = configVariables.OAUTH2_AUTHORITY
-
-function getAuthorityHost(url: string): string {
-  try {
-    return new URL(url).host
-  } catch {
-    return url
-  }
-}
-
 export const msalConfig: Configuration = {
   auth: {
     clientId: configVariables.OAUTH2_CLIENT_ID,
-    authority,
-    knownAuthorities: [getAuthorityHost(authority)],
+    authority: configVariables.OAUTH2_AUTHORITY,
+    knownAuthorities: [new URL(configVariables.OAUTH2_AUTHORITY).host],
     protocolMode: ProtocolMode.OIDC,
 
     OIDCOptions: {

--- a/src/init/msal-config.ts
+++ b/src/init/msal-config.ts
@@ -1,11 +1,23 @@
 import { type Configuration, ProtocolMode, ServerResponseType } from '@azure/msal-browser'
 import { configVariables } from '../utils/config'
 
+const authority = configVariables.OAUTH2_AUTHORITY
+
+function getAuthorityHost(url: string): string {
+  try {
+    return new URL(url).host
+  } catch {
+    return url
+  }
+}
+
 export const msalConfig: Configuration = {
   auth: {
     clientId: configVariables.OAUTH2_CLIENT_ID,
-    authority: configVariables.OAUTH2_AUTHORITY,
+    authority,
+    knownAuthorities: [getAuthorityHost(authority)],
     protocolMode: ProtocolMode.OIDC,
+
     OIDCOptions: {
       serverResponseType: ServerResponseType.QUERY,
     },

--- a/src/init/msal-config.ts
+++ b/src/init/msal-config.ts
@@ -7,7 +7,6 @@ export const msalConfig: Configuration = {
     authority: configVariables.OAUTH2_AUTHORITY,
     knownAuthorities: [new URL(configVariables.OAUTH2_AUTHORITY).host],
     protocolMode: ProtocolMode.OIDC,
-
     OIDCOptions: {
       serverResponseType: ServerResponseType.QUERY,
     },


### PR DESCRIPTION
Include known authorities in the MSAL configuration to enable fetching OIDC configuration correctly. This change enhances the authority handling by extracting the host from the authority URL.