### PR TITLE
fix: Handle additional timeout error in fetch error data

### DIFF
--- a/src/store/utils/parse-errors.ts
+++ b/src/store/utils/parse-errors.ts
@@ -47,7 +47,11 @@ export function getFetchErrorData(error: ManagedErrors): {
   }
 
   if (IsMSALError(error)) {
-    if (error.message.includes('refresh_token_expired') || error.message.includes('no_account_error')) {
+    if (
+      error.message.includes('refresh_token_expired') ||
+      error.message.includes('no_account_error') ||
+      error.message.includes('timed_out')
+    ) {
       return {
         code: undefined,
         message: 'Session expired. Please login again.',


### PR DESCRIPTION
Kanskje vi burde trigge session-clear og tvinge re-auth for alle MSAL errors?

For å trigge feilmeldingen la jeg endra jeg `src/store/configs/index.ts` litt:

```ts
import { BrowserAuthError } from '@azure/msal-browser'
import { type BaseQueryApi, createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
import { configVariables } from '../../utils/config'
import type { RootState } from '../store'

/** Override for text/plain response handler */
const responseHandler = (response: Response) => {
  const contentType = response.headers.get('content-type')
  return !contentType || contentType.includes('text/plain') ? response.text() : response.json()
}

const proxyPrepareHeaders = async (headers: Headers, { getState }: Pick<BaseQueryApi, 'getState'>) => {
  const state = getState() as RootState
  const provider = state.auth.provider

  if (!provider || !provider.radixApiAuthProvider) {
    return headers
  }

  // La inn en MSAL Error her:
  throw new BrowserAuthError('timed_out', 'xyz', 'Some random error message')

  const token = await provider.radixApiAuthProvider.getAccessToken()
  headers.set('Authorization', `Bearer ${token}`)
  return headers
}
```


<img width="2936" height="1886" alt="image" src="https://github.com/user-attachments/assets/f97995d9-cf1d-464d-8413-495d9e306f97" />
