### PR TITLE
Fix: recover when a session can't be silently renewed

### DIFF
--- a/src/components/code/log.tsx
+++ b/src/components/code/log.tsx
@@ -10,6 +10,7 @@ import './style.css'
 import { FitAddon } from '@xterm/addon-fit'
 import { EventSource } from 'eventsource'
 import { useStore } from 'react-redux'
+import { acquireAccessToken } from '../../store/msal/interactive-auth'
 import type { RootState } from '../../store/store'
 import { LoadingButton } from '../button/loading-button'
 
@@ -219,8 +220,7 @@ const useAuthentication = () => {
       return
     }
 
-    authProvider
-      .getAccessToken()
+    acquireAccessToken(authProvider)
       .then((token) => setToken(token))
       .catch((err) => setTokenError(err))
   }, [authProvider])

--- a/src/init/entry-default.tsx
+++ b/src/init/entry-default.tsx
@@ -10,6 +10,20 @@ import { msalConfig } from './msal-config'
 
 const msal = new PublicClientApplication(msalConfig)
 
+// TODO: TEMP DEV MOCK — remove before merging to release branch
+// const realAcquireTokenSilent = msal.acquireTokenSilent.bind(msal)
+// const mockTokenExpiresAt = Date.now() + 10_000
+// msal.acquireTokenSilent = ((...args: Parameters<typeof realAcquireTokenSilent>) => {
+//   if (Date.now() < mockTokenExpiresAt) {
+//     return realAcquireTokenSilent(...args)
+//   }
+
+//   const timedOutError = new Error('timed_out: See https://aka.ms/msal.js/errors#timed_out for details')
+//   timedOutError.name = 'BrowserAuthError'
+//   console.error(timedOutError)
+//   return Promise.reject(timedOutError)
+// }) as typeof msal.acquireTokenSilent
+
 msal.initialize().then(() => {
   if (!msal.getActiveAccount() && msal.getAllAccounts().length > 0) {
     msal.setActiveAccount(msal.getAllAccounts()[0])

--- a/src/pages/session-expired/SessionExpiredPage.tsx
+++ b/src/pages/session-expired/SessionExpiredPage.tsx
@@ -2,9 +2,14 @@ import { Button, Typography } from '@equinor/eds-core-react'
 import { HomeIcon } from '../../components/home-icon'
 
 export default function SessionExpiredPage() {
+  /**
+   * Must stay a full-page navigation: it's what clears the cached terminalAuthError
+   * guard in store/msal/interactive-auth.ts. A popup/SPA re-login would leave the
+   * guard set and lock the user out, clear it explicitly if you change this.
+   */
   const handleReauth = () => {
     sessionStorage.clear()
-    window.location.href = '/applications'
+    window.location.href = '/applications' // Do not remove this without reading function comment above.
   }
 
   return (

--- a/src/store/configs/index.ts
+++ b/src/store/configs/index.ts
@@ -1,5 +1,6 @@
 import { type BaseQueryApi, createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { configVariables } from '../../utils/config'
+import { acquireAccessToken } from '../msal/interactive-auth'
 import type { RootState } from '../store'
 
 /** Override for text/plain response handler */
@@ -16,7 +17,7 @@ const proxyPrepareHeaders = async (headers: Headers, { getState }: Pick<BaseQuer
     return headers
   }
 
-  const token = await provider.radixApiAuthProvider.getAccessToken()
+  const token = await acquireAccessToken(provider.radixApiAuthProvider)
   headers.set('Authorization', `Bearer ${token}`)
   return headers
 }
@@ -74,7 +75,7 @@ export const serviceNowStoreApi = createApi({
       const provider = state.auth.provider
       if (!provider || !provider.serviceNowAuthProvider) return headers
 
-      const token = await provider.serviceNowAuthProvider.getAccessToken()
+      const token = await acquireAccessToken(provider.serviceNowAuthProvider)
       headers.set('Authorization', `Bearer ${token}`)
 
       return headers

--- a/src/store/msal/interactive-auth.ts
+++ b/src/store/msal/interactive-auth.ts
@@ -1,0 +1,78 @@
+import { InteractionRequiredAuthError } from '@azure/msal-browser'
+
+type TokenProvider = { getAccessToken: () => Promise<string> }
+
+/**
+ * This file is the source of truth for deciding "is this auth session dead, or just a hiccup?".
+ */
+
+/**
+ * List of error codes/messages that mean "the user needs to log in again".
+ *
+ * Note timed_out / monitor_window_timeout — A bit misleading used here.
+ * The hidden silent-renewal iframe never came back in time. It's what we see
+ * when the token endpoint keeps rejecting the expired refresh token, so we
+ * treat it as "time to log in again" rather than looping forever.
+ */
+const INTERACTION_REQUIRED_SIGNALS = [
+  'refresh_token_expired', // the refresh token is done, nothing left to renew with
+  'no_account_error', // MSAL has no account to renew for
+  'interaction_required', // User must manually sign in
+  'login_required', // User must manually sign in
+  'invalid_grant', // the refresh token is done, nothing left to renew with
+  'aadsts70043', // the refresh token is done, nothing left to renew with
+  'timed_out', // the hidden silent-renewal iframe never came back in time
+  'monitor_window_timeout', // the hidden silent-renewal iframe never came back in time
+]
+
+/**
+ * Checks if an error is one of the MSAL errors that means "the user needs to log in again".
+ */
+export function requiresInteractiveLogin(error: unknown): boolean {
+  // Friendly error from MSAL that means "the user needs to log in again"
+  if (error instanceof InteractionRequiredAuthError) {
+    return true
+  }
+
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+
+  // Fallback to checking the error name, error code, and message, because
+  // some of these (looking at you, `BrowserAuthError: timed_out`)
+  // don't arrive as that nice typed error...
+  const parts: Array<string> = []
+  if ('name' in error && typeof error.name === 'string') parts.push(error.name)
+  if ('errorCode' in error && typeof error.errorCode === 'string') parts.push(error.errorCode)
+  if ('message' in error && typeof error.message === 'string') parts.push(error.message)
+
+  const errorText = parts.join(' ').toLowerCase()
+  return INTERACTION_REQUIRED_SIGNALS.some((signal) => errorText.includes(signal))
+}
+
+// The first "you need to log in again" error we hit, cached so later calls fail fast.
+// NOTE: this only resets on a full page load. That's fine because every re-auth path
+// today is a hard navigation. If a popup-based login is ever added it
+// won't reload the page, so it would need to clear this flag explicitly.
+let terminalAuthError: unknown = null
+
+/**
+ * Gets an access token for an API call.
+ * Before returning, checks if we've already hit a terminal auth error and throws it again if so,
+ * preventing any further API calls from being made until the user re-authenticates.
+ * This prevents an endless loop of failed API calls when the refresh token has expired.
+ */
+export async function acquireAccessToken(authProvider: TokenProvider): Promise<string> {
+  if (terminalAuthError) {
+    throw terminalAuthError
+  }
+
+  try {
+    return await authProvider.getAccessToken()
+  } catch (error) {
+    if (requiresInteractiveLogin(error)) {
+      terminalAuthError = error
+    }
+    throw error
+  }
+}

--- a/src/store/utils/parse-errors.ts
+++ b/src/store/utils/parse-errors.ts
@@ -2,6 +2,7 @@ import type { SerializedError } from '@reduxjs/toolkit'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { getReasonPhrase } from 'http-status-codes'
 
+import { requiresInteractiveLogin } from '../msal/interactive-auth'
 import type { FetchQueryError } from '../types'
 
 type ManagedErrors = FetchQueryError | SerializedError | Error | unknown
@@ -47,7 +48,7 @@ export function getFetchErrorData(error: ManagedErrors): {
   }
 
   if (IsMSALError(error)) {
-    if (error.message.includes('refresh_token_expired') || error.message.includes('no_account_error')) {
+    if (requiresInteractiveLogin(error)) {
       return {
         code: undefined,
         message: 'Session expired. Please login again.',


### PR DESCRIPTION

I think this will fix it, but we need it in dev to test properly. If this works I will remove the commented out code that I included in this PR. 

### What's the problem?
When a user's session hits the Conditional Access sign-in-frequency limit (refresh token maxes out around 12h), MSAL's silent renewal starts failing, showing up as `BrowserAuthError: timed_out` or an `invalid_grant` / `AADSTS70043` response.

The app didn't recognise these as "you need to log in again". So instead of sending the user to re-authenticate, it showed a generic "That didn't work" error, and every polling query just kept retrying. Resulting in each one stuck in the same authorize(200 OK)/token(400 Bad request) endless loop.

<img width="1149" height="1265" alt="image" src="https://github.com/user-attachments/assets/83cab12a-f080-4bfb-a2bb-0c842296cf6b" />



### What's the fix?
Single source of truth for error handling interactive auth: `src/store/msal/interactive-auth.ts`. (MSAL refers to it as InteractionRequiredAuthError)

- **`requiresInteractiveLogin(error)`** — single source of truth for "is this session dead?". Trusts MSAL's own `InteractionRequiredAuthError` when present, otherwise matches a small list of known errors (`invalid_grant`, `aadsts70043`, `timed_out`, etc.).
- **`acquireAccessToken(provider)`** — wraps token acquisition for every API. The first time a terminal auth error happens it caches it and fails fast on all later calls, so one dead session no longer spins up an infinite renewal loop across all the polling queries.

Everything is wired to use the same detection:
- All RTK Query `prepareHeaders` (radix / cost / log / scan / serviceNow) now go through `acquireAccessToken`.
- `parse-errors.ts` uses the shared `requiresInteractiveLogin`, so the UI routes to the **Session expired** page instead of a generic error.

### Notes
- The cached guard resets on a full page reload, which is what every re-auth path already does (documented inline in `interactive-auth.ts` and `SessionExpiredPage.tsx`).
- No behaviour change on the happy path — same token, same headers

### Testing
Needs to be tested with real authentication. Keep a tab open (eg. https://console.dev.radix.equinor.com/applications/radix-canary-golang) for 12-14 hours. Try interacting with it tomorrow when the refresh token has expired. If this fix works you should be prompted to reauthenticate. 



### Screenshots of the original error:
<img width="2330" height="654" alt="Screenshot 2026-07-31 at 09 50 03" src="https://github.com/user-attachments/assets/e8987a4a-6a70-4c85-a4e8-467a3bdda85d" />
<img width="1149" height="1265" alt="Screenshot 2026-07-31 at 09 55 24" src="https://github.com/user-attachments/assets/08722bce-7115-4964-9ea2-711f83d24c3c" />
<img width="1149" height="1265" alt="Screenshot 2026-07-31 at 09 58 00" src="https://github.com/user-attachments/assets/97264550-427f-4500-837c-3e3f3cac37d6" />
<img width="1055" height="1234" alt="Skjermbilde 2026-07-31 kl  12 38 31" src="https://github.com/user-attachments/assets/8573731d-90b0-4e84-8f4a-6d6f8717a374" />

