### PR TITLE
fix: Redirect user if token access fails

### DIFF
--- a/src/components/async-resource/async-resource.tsx
+++ b/src/components/async-resource/async-resource.tsx
@@ -1,9 +1,7 @@
 import { CircularProgress, Typography } from '@equinor/eds-core-react'
-import { type PropsWithChildren, type ReactNode, useEffect } from 'react'
-import { useNavigate } from 'react-router'
+import type { PropsWithChildren, ReactNode } from 'react'
 
 import { externalUrls } from '../../externalUrls'
-import { routes } from '../../router/routes'
 import type { FetchQueryResult } from '../../store/types'
 import { getFetchErrorData } from '../../store/utils/parse-errors'
 import { Alert } from '../alert'
@@ -23,17 +21,7 @@ export default function AsyncResource({
   errorContent,
   nonFailureErrorCodes: nonErrorCodes,
 }: AnotherAsyncResourceProps) {
-  const { code, message, action } = asyncState?.error ? getFetchErrorData(asyncState.error) : {}
-
-  const navigate = useNavigate()
-
-  useEffect(() => {
-    if (action !== 'refresh_msal_auth') {
-      return
-    }
-
-    navigate(routes.sessionExpired, { replace: true })
-  }, [action, navigate])
+  const { code, message } = asyncState?.error ? getFetchErrorData(asyncState.error) : {}
 
   if (!asyncState || asyncState.isLoading) {
     return (

--- a/src/init/entry-default.tsx
+++ b/src/init/entry-default.tsx
@@ -5,24 +5,22 @@ import { Provider } from 'react-redux'
 import { MsalAuthProvider } from '../components/msal-auth-context/msal-auth-provider'
 import { PageRouter } from '../components/page-root'
 import { router } from '../router/router'
+import { routes } from '../router/routes'
+import { setTerminalAuthErrorHandler } from '../store/msal/interactive-auth'
 import store from '../store/store'
 import { msalConfig } from './msal-config'
 
 const msal = new PublicClientApplication(msalConfig)
 
-// TODO: TEMP DEV MOCK — remove before merging to release branch
-// const realAcquireTokenSilent = msal.acquireTokenSilent.bind(msal)
-// const mockTokenExpiresAt = Date.now() + 10_000
-// msal.acquireTokenSilent = ((...args: Parameters<typeof realAcquireTokenSilent>) => {
-//   if (Date.now() < mockTokenExpiresAt) {
-//     return realAcquireTokenSilent(...args)
-//   }
-
-//   const timedOutError = new Error('timed_out: See https://aka.ms/msal.js/errors#timed_out for details')
-//   timedOutError.name = 'BrowserAuthError'
-//   console.error(timedOutError)
-//   return Promise.reject(timedOutError)
-// }) as typeof msal.acquireTokenSilent
+// When the session dies, send the user to the session-expired page. Handled
+// centrally here so no data-loading component has to know about session expiry.
+setTerminalAuthErrorHandler(() => {
+  // Prevent redirect loop
+  if (router.state.location.pathname === routes.sessionExpired) {
+    return
+  }
+  router.navigate(routes.sessionExpired, { replace: true })
+})
 
 msal.initialize().then(() => {
   if (!msal.getActiveAccount() && msal.getAllAccounts().length > 0) {

--- a/src/store/msal/interactive-auth.ts
+++ b/src/store/msal/interactive-auth.ts
@@ -1,6 +1,9 @@
 import { InteractionRequiredAuthError } from '@azure/msal-browser'
+import type { AuthCodeMSALBrowserAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/authCodeMsalBrowser'
 
-type TokenProvider = { getAccessToken: () => Promise<string> }
+export const REFRESH_MSAL_AUTH_ERROR = 'refresh_msal_auth'
+
+type TokenProvider = Pick<AuthCodeMSALBrowserAuthenticationProvider, 'getAccessToken'>
 
 /**
  * This file is the source of truth for deciding "is this auth session dead, or just a hiccup?".
@@ -57,6 +60,21 @@ export function requiresInteractiveLogin(error: unknown): boolean {
 let terminalAuthError: unknown = null
 
 /**
+ * Callback fired whenever an access token is requested while the session is
+ * dead. May fire many times (every guarded call), so the handler must make sure
+ * it doesn't trigger multiple navigations or toasts.
+ */
+let onTerminalAuthError: ((error: unknown) => void) | null = null
+
+/**
+ * Registers the callback invoked when the session is detected as dead.
+ * Kept as dependency injection so this auth module stays decoupled from routing.
+ */
+export function setTerminalAuthErrorHandler(handler: (error: unknown) => void): void {
+  onTerminalAuthError = handler
+}
+
+/**
  * Gets an access token for an API call.
  * Before returning, checks if we've already hit a terminal auth error and throws it again if so,
  * preventing any further API calls from being made until the user re-authenticates.
@@ -64,6 +82,7 @@ let terminalAuthError: unknown = null
  */
 export async function acquireAccessToken(authProvider: TokenProvider): Promise<string> {
   if (terminalAuthError) {
+    onTerminalAuthError?.(terminalAuthError)
     throw terminalAuthError
   }
 
@@ -72,6 +91,7 @@ export async function acquireAccessToken(authProvider: TokenProvider): Promise<s
   } catch (error) {
     if (requiresInteractiveLogin(error)) {
       terminalAuthError = error
+      onTerminalAuthError?.(error)
     }
     throw error
   }

--- a/src/store/utils/parse-errors.ts
+++ b/src/store/utils/parse-errors.ts
@@ -1,8 +1,7 @@
 import type { SerializedError } from '@reduxjs/toolkit'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { getReasonPhrase } from 'http-status-codes'
-
-import { requiresInteractiveLogin } from '../msal/interactive-auth'
+import { REFRESH_MSAL_AUTH_ERROR, requiresInteractiveLogin } from '../msal/interactive-auth'
 import type { FetchQueryError } from '../types'
 
 type ManagedErrors = FetchQueryError | SerializedError | Error | unknown
@@ -20,7 +19,7 @@ export function getFetchErrorData(error: ManagedErrors): {
   code?: number
   message: string
   error: string
-  action?: undefined | 'refresh_msal_auth'
+  action?: typeof REFRESH_MSAL_AUTH_ERROR
 } {
   if (typeof error === 'string') {
     return {
@@ -53,7 +52,7 @@ export function getFetchErrorData(error: ManagedErrors): {
         code: undefined,
         message: 'Session expired. Please login again.',
         error: error.name,
-        action: 'refresh_msal_auth',
+        action: REFRESH_MSAL_AUTH_ERROR,
       }
     }
 

--- a/src/utils/promise-handler.ts
+++ b/src/utils/promise-handler.ts
@@ -1,9 +1,17 @@
 import { errorToast } from '../components/global-top-nav/styled-toaster'
+import { REFRESH_MSAL_AUTH_ERROR } from '../store/msal/interactive-auth'
+import { getFetchErrorData } from '../store/utils/parse-errors'
 
 export function promiseHandler<T>(
   promise: Promise<T>,
   onSuccess: ((data: T) => void) | undefined,
   errMsg = 'Error'
 ): void {
-  promise.then(onSuccess).catch((err) => errorToast(`${errMsg}: ${err.message}`))
+  promise.then(onSuccess).catch((err) => {
+    // A dead session redirects to the session-expired page, do not toast.
+    if (getFetchErrorData(err).action === REFRESH_MSAL_AUTH_ERROR) {
+      return
+    }
+    errorToast(`${errMsg}: ${err.message}`)
+  })
 }

--- a/src/utils/promise-handler.ts
+++ b/src/utils/promise-handler.ts
@@ -8,10 +8,13 @@ export function promiseHandler<T>(
   errMsg = 'Error'
 ): void {
   promise.then(onSuccess).catch((err) => {
+    const { action, message } = getFetchErrorData(err)
+
     // A dead session redirects to the session-expired page, do not toast.
-    if (getFetchErrorData(err).action === REFRESH_MSAL_AUTH_ERROR) {
+    if (action === REFRESH_MSAL_AUTH_ERROR) {
       return
     }
-    errorToast(`${errMsg}: ${err.message}`)
+
+    errorToast(`${errMsg}: ${message}`)
   })
 }


### PR DESCRIPTION
Follow up PR for https://github.com/equinor/radix-web-console/pull/1380.

## The issue

Parts of the application did not use the re-usable AsyncResource component. This component was the one in charge of redirecting users to the Session Expired Page. In the last PR I added a centralized method for catching various session expired errors/signals. This code worked, but was dependent on redirects from AsyncResource. 

## What changed

Moved the redirect responsibility away from the optionally used AsyncResource, and implemented it as a part of acquiring access token. To keep the token code modular (and not a part of the React code) I used dependency injection to add a router callback that would redirect the user. 

Since we do multiple queries at the same time it is important that the callback do not allow navigation from Session Expired Page to Session Expired Page. 

Whenever the user triggers an API call this happens: 
Happy path:
1. All API calls needs a token and runs `acquireAccessToken`
2. `acquireAccessToken` tries to fetch token
3. MSAL returns access token
4. Access token is used to communicate with the API

Session expired path:
1. All API calls needs a token and runs `acquireAccessToken`
2. `acquireAccessToken` tries to fetch token
3. MSAL fails (can take up to 10 seconds)
4. If the error is a recognized "must log in again" signal (requiresInteractiveLogin) is set to that error. Other errors are just thrown as usual.
5. `onTerminalAuthError` callback is ran.
6. user is navigated to Session Expired Page
7. User decides to not login, and navigates to another page
8. `acquireAccessToken` is ran
9. Sees`terminalAuthError` is set, runs the`onTerminalAuthError` callback (which redirects), and re-throws the error so the API call still fails fast.