### PR TITLE
fix: Remove shared secret from configuration and update regeneration logic

### DIFF
--- a/src/components/banner/Banner.stories.tsx
+++ b/src/components/banner/Banner.stories.tsx
@@ -44,6 +44,24 @@ export const WarningBanner: Story = {
   ),
 }
 
+export const SuccessBanner: Story = {
+  args: { variant: 'success' },
+  render: (args) => (
+    <Banner {...args}>
+      <Banner.Message>This is a success banner</Banner.Message>
+    </Banner>
+  ),
+}
+
+export const DangerBanner: Story = {
+  args: { variant: 'danger' },
+  render: (args) => (
+    <Banner {...args}>
+      <Banner.Message>This is a danger banner</Banner.Message>
+    </Banner>
+  ),
+}
+
 export const WithDismiss: Story = {
   args: { onDismiss: () => alert('Banner dismissed') },
   render: (args) => (

--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -1,11 +1,18 @@
 import { Button, Icon, Typography } from '@equinor/eds-core-react'
-import { close, type IconData, info_circle, warning_outlined } from '@equinor/eds-icons'
+import {
+  check_circle_outlined,
+  close,
+  error_outlined,
+  type IconData,
+  info_circle,
+  warning_outlined,
+} from '@equinor/eds-icons'
 import clsx from 'clsx'
 import type { ReactNode } from 'react'
 
 import styles from './banner.module.css'
 
-type BannerVariant = 'info' | 'warning'
+type BannerVariant = 'info' | 'warning' | 'success' | 'danger'
 
 export interface BannerProps {
   /** Visual style of the banner. */
@@ -20,6 +27,8 @@ export interface BannerProps {
 const bannerVariants: Record<BannerVariant, { className: string; icon: IconData }> = {
   warning: { className: styles.warning, icon: warning_outlined },
   info: { className: styles.info, icon: info_circle },
+  success: { className: styles.success, icon: check_circle_outlined },
+  danger: { className: styles.danger, icon: error_outlined },
 }
 
 const BannerRoot = ({ className, variant = 'info', children, onDismiss }: BannerProps) => {

--- a/src/components/banner/banner.module.css
+++ b/src/components/banner/banner.module.css
@@ -58,4 +58,30 @@
       color: var(--temp-eds-2-color-warning-12);
     }
   }
+
+  /* Variant - Success */
+  &.success {
+    background-color: var(--temp-eds-2-color-success-2);
+    border-color: var(--temp-eds-2-color-success-7);
+
+    .icon {
+      fill: var(--temp-eds-2-color-success-12);
+    }
+    .closeButton {
+      color: var(--temp-eds-2-color-success-12);
+    }
+  }
+
+  /* Variant - Danger */
+  &.danger {
+    background-color: var(--temp-eds-2-color-danger-2);
+    border-color: var(--temp-eds-2-color-danger-7);
+
+    .icon {
+      fill: var(--temp-eds-2-color-danger-12);
+    }
+    .closeButton {
+      color: var(--temp-eds-2-color-danger-12);
+    }
+  }
 }

--- a/src/components/configure-application-github/configure-git-hub-webhook.tsx
+++ b/src/components/configure-application-github/configure-git-hub-webhook.tsx
@@ -33,7 +33,7 @@ export function ConfigureGitHubWebhook({ repository, appName, sharedSecret }: Pr
             {sharedSecret ? (
               <>
                 <code style={{ verticalAlign: 'middle', minWidth: '10em', minHeight: '1.5em' }}>{sharedSecret}</code>{' '}
-                <CompactCopyButton content={sharedSecret ?? ''} />
+                <CompactCopyButton content={sharedSecret} />
               </>
             ) : (
               <CircularProgress size={16} />

--- a/src/components/configure-application-github/configure-git-hub-webhook.tsx
+++ b/src/components/configure-application-github/configure-git-hub-webhook.tsx
@@ -1,4 +1,4 @@
-import { List, Typography } from '@equinor/eds-core-react'
+import { CircularProgress, List, Typography } from '@equinor/eds-core-react'
 import { configVariables } from '../../utils/config'
 import { CompactCopyButton } from '../compact-copy-button'
 import { ExternalLink } from '../link/external-link'
@@ -30,8 +30,14 @@ export function ConfigureGitHubWebhook({ repository, appName, sharedSecret }: Pr
           </List.Item>
           <List.Item>
             Set <em>Secret</em> to{' '}
-            <code style={{ verticalAlign: 'middle', minWidth: '10em', minHeight: '1.5em' }}>{sharedSecret}</code>{' '}
-            <CompactCopyButton content={sharedSecret ?? ''} />
+            {sharedSecret ? (
+              <>
+                <code style={{ verticalAlign: 'middle', minWidth: '10em', minHeight: '1.5em' }}>{sharedSecret}</code>{' '}
+                <CompactCopyButton content={sharedSecret ?? ''} />
+              </>
+            ) : (
+              <CircularProgress size={16} />
+            )}
           </List.Item>
           <List.Item>Press "Add webhook"</List.Item>
         </List>

--- a/src/components/configure-application-github/index.stories.tsx
+++ b/src/components/configure-application-github/index.stories.tsx
@@ -31,7 +31,6 @@ const meta = {
       readerAdUsers: ['Reader User 1', 'Reader User 2'],
       name: 'a-name-thing',
       repository: 'https://some/path/to/a/repo',
-      sharedSecret: 'a long shared secret',
       configBranch: 'configBranch',
       creator: 'creator',
       owner: 'owner',

--- a/src/components/configure-application-github/regenerate-shared-secret-scrim.tsx
+++ b/src/components/configure-application-github/regenerate-shared-secret-scrim.tsx
@@ -18,12 +18,7 @@ export function RegenerateSharedSecretScrim({ appName, refetchSecrets }: Props) 
 
   const onRegenerate = handlePromiseWithToast(async () => {
     setShow(false)
-    await regenerateSecrets({
-      appName,
-      regenerateSharedSecretData: {
-        sharedSecret: crypto.randomUUID(),
-      },
-    }).unwrap()
+    await regenerateSecrets({ appName }).unwrap()
     await refetchSecrets()
   })
 

--- a/src/components/create-application/index.tsx
+++ b/src/components/create-application/index.tsx
@@ -6,7 +6,6 @@ import {
 } from '../../store/radix-api'
 import './style.css'
 import { useState } from 'react'
-import { pollingInterval } from '../../store/defaults'
 import { CreateApplicationScrim } from './create-application-scrim'
 
 export default function PageCreateApplication() {
@@ -16,7 +15,7 @@ export default function PageCreateApplication() {
 
   const { data: secrets, refetch: refetchSecrets } = useGetDeployKeyAndSecretQuery(
     { appName: appName! },
-    { pollingInterval, skip: !appName }
+    { pollingInterval: 5000, skip: !appName }
   )
 
   const onCreateApplication = async (

--- a/src/pages/configuration/ConfigurationPage.tsx
+++ b/src/pages/configuration/ConfigurationPage.tsx
@@ -115,7 +115,7 @@ function ConfigurationPage({ appName }: { appName: string }) {
               <ChangeRepositoryForm
                 appName={appName}
                 repository={registration.repository}
-                sharedSecret={secrets?.sharedSecret ?? ''}
+                sharedSecret={secrets?.sharedSecret}
                 refetch={refetch}
               />
               <ChangeConfigBranchForm appName={appName} configBranch={registration.configBranch} refetch={refetch} />

--- a/src/pages/configuration/ConfigurationPage.tsx
+++ b/src/pages/configuration/ConfigurationPage.tsx
@@ -115,7 +115,7 @@ function ConfigurationPage({ appName }: { appName: string }) {
               <ChangeRepositoryForm
                 appName={appName}
                 repository={registration.repository}
-                sharedSecret={registration.sharedSecret}
+                sharedSecret={secrets?.sharedSecret ?? ''}
                 refetch={refetch}
               />
               <ChangeConfigBranchForm appName={appName} configBranch={registration.configBranch} refetch={refetch} />

--- a/src/pages/configuration/ConfigurationPage.tsx
+++ b/src/pages/configuration/ConfigurationPage.tsx
@@ -112,12 +112,7 @@ function ConfigurationPage({ appName }: { appName: string }) {
             <section className="grid grid--gap-small">
               <Typography variant="h4">Danger Zone</Typography>
               <ChangeAdminForm registration={registration} refetch={refetch} />
-              <ChangeRepositoryForm
-                appName={appName}
-                repository={registration.repository}
-                sharedSecret={secrets?.sharedSecret}
-                refetch={refetch}
-              />
+              <ChangeRepositoryForm appName={appName} repository={registration.repository} refetch={refetch} />
               <ChangeConfigBranchForm appName={appName} configBranch={registration.configBranch} refetch={refetch} />
               <ChangeConfigFileForm
                 refetch={refetch}

--- a/src/pages/configuration/components/ChangeRepositoryForm.tsx
+++ b/src/pages/configuration/components/ChangeRepositoryForm.tsx
@@ -1,6 +1,6 @@
 import { Accordion, Button, Checkbox, CircularProgress, List, TextField, Typography } from '@equinor/eds-core-react'
 import { type ChangeEvent, type SubmitEventHandler, useState } from 'react'
-import { Alert } from '../../../components/alert'
+import { Banner } from '../../../components/banner/Banner'
 import { handlePromiseWithToast } from '../../../components/global-top-nav/styled-toaster'
 import { useModifyRegistrationDetailsMutation } from '../../../store/radix-api'
 import { getFetchErrorMessage } from '../../../store/utils/parse-errors'
@@ -44,7 +44,9 @@ export function ChangeRepositoryForm({ appName, repository, refetch }: Props) {
             <form className="grid grid--gap-medium" onSubmit={handleSubmit}>
               {error && (
                 <div>
-                  <Alert type="danger">Failed to change repository. {getFetchErrorMessage(error)}</Alert>
+                  <Banner variant="danger">
+                    <Banner.Message>Failed to change repository. {getFetchErrorMessage(error)}</Banner.Message>
+                  </Banner>
                 </div>
               )}
               <TextField
@@ -65,7 +67,9 @@ export function ChangeRepositoryForm({ appName, repository, refetch }: Props) {
                   <List>
                     {modifyState?.warnings.map((warning, i) => (
                       <List.Item key={i}>
-                        <Alert type="warning">{warning}</Alert>
+                        <Banner variant="warning">
+                          <Banner.Message>{warning}</Banner.Message>
+                        </Banner>
                       </List.Item>
                     ))}
                   </List>
@@ -94,7 +98,11 @@ export function ChangeRepositoryForm({ appName, repository, refetch }: Props) {
               )}
             </form>
             {!isLoading && isSuccess && (
-              <Alert type="success">Success: Remember to update your deploy key and your webhooks shared secret</Alert>
+              <Banner variant="success">
+                <Banner.Message>
+                  Repository updated. Remember to update your deploy key and your webhooks shared secret.
+                </Banner.Message>
+              </Banner>
             )}
           </div>
         </Accordion.Panel>

--- a/src/pages/configuration/components/ChangeRepositoryForm.tsx
+++ b/src/pages/configuration/components/ChangeRepositoryForm.tsx
@@ -100,7 +100,15 @@ export function ChangeRepositoryForm({ appName, repository, refetch }: Props) {
             {!isLoading && isSuccess && (
               <Banner variant="success">
                 <Banner.Message>
-                  Repository updated. Remember to update your deploy key and your webhooks shared secret.
+                  Repository updated. Remember to update your{' '}
+                  <a
+                    href="https://radix.equinor.com/start/registering-app/#deploy-key"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    deploy key
+                  </a>{' '}
+                  and your webhooks shared secret if you use it.
                 </Banner.Message>
               </Banner>
             )}

--- a/src/pages/configuration/components/ChangeRepositoryForm.tsx
+++ b/src/pages/configuration/components/ChangeRepositoryForm.tsx
@@ -2,6 +2,7 @@ import { Accordion, Button, Checkbox, CircularProgress, List, TextField, Typogra
 import { type ChangeEvent, type SubmitEventHandler, useState } from 'react'
 import { Banner } from '../../../components/banner/Banner'
 import { handlePromiseWithToast } from '../../../components/global-top-nav/styled-toaster'
+import { ExternalLink } from '../../../components/link/external-link'
 import { useModifyRegistrationDetailsMutation } from '../../../store/radix-api'
 import { getFetchErrorMessage } from '../../../store/utils/parse-errors'
 
@@ -101,13 +102,9 @@ export function ChangeRepositoryForm({ appName, repository, refetch }: Props) {
               <Banner variant="success">
                 <Banner.Message>
                   Repository updated. Remember to update your{' '}
-                  <a
-                    href="https://radix.equinor.com/start/registering-app/#deploy-key"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
+                  <ExternalLink href="https://radix.equinor.com/start/registering-app/#deploy-key">
                     deploy key
-                  </a>{' '}
+                  </ExternalLink>{' '}
                   and your webhooks shared secret if you use it.
                 </Banner.Message>
               </Banner>

--- a/src/pages/configuration/components/ChangeRepositoryForm.tsx
+++ b/src/pages/configuration/components/ChangeRepositoryForm.tsx
@@ -1,44 +1,21 @@
 import { Accordion, Button, Checkbox, CircularProgress, List, TextField, Typography } from '@equinor/eds-core-react'
-import { type ChangeEvent, type FormEvent, useState } from 'react'
+import { type ChangeEvent, type SubmitEventHandler, useState } from 'react'
 import { Alert } from '../../../components/alert'
-import AsyncResource from '../../../components/async-resource/async-resource'
-import { Code } from '../../../components/code/code'
-import { CompactCopyButton } from '../../../components/compact-copy-button'
-import imageDeployKey from '../../../components/configure-application-github/deploy-key02.png'
-import imageWebhook from '../../../components/configure-application-github/webhook01.png'
 import { handlePromiseWithToast } from '../../../components/global-top-nav/styled-toaster'
-import { ExternalLink } from '../../../components/link/external-link'
-import { pollingInterval } from '../../../store/defaults'
-import { useGetDeployKeyAndSecretQuery, useModifyRegistrationDetailsMutation } from '../../../store/radix-api'
+import { useModifyRegistrationDetailsMutation } from '../../../store/radix-api'
 import { getFetchErrorMessage } from '../../../store/utils/parse-errors'
-import { configVariables } from '../../../utils/config'
-
-const radixZoneDNS = configVariables.RADIX_DNS_ZONE
-
-const DeployKey = ({ appName }: { appName: string }) => {
-  const { data: deployKeAndSecret, ...depAndSecState } = useGetDeployKeyAndSecretQuery({ appName }, { pollingInterval })
-
-  return (
-    <AsyncResource asyncState={depAndSecState}>
-      <Code copy content={deployKeAndSecret?.publicDeployKey ?? ''} />
-    </AsyncResource>
-  )
-}
 
 interface Props {
   appName: string
   repository: string
   refetch: () => unknown
-  sharedSecret?: string
 }
-export function ChangeRepositoryForm({ appName, repository, refetch, sharedSecret }: Props) {
+export function ChangeRepositoryForm({ appName, repository, refetch }: Props) {
   const [currentRepository, setCurrentRepository] = useState(repository)
   const [useAcknowledgeWarnings, setAcknowledgeWarnings] = useState(false)
   const [mutate, { isLoading, error, data: modifyState, isSuccess }] = useModifyRegistrationDetailsMutation()
 
-  const webhookURL = `https://webhook.${radixZoneDNS}/events/github?appName=${appName}`
-
-  const handleSubmit = handlePromiseWithToast(async (ev: FormEvent) => {
+  const handleSubmit: SubmitEventHandler = handlePromiseWithToast(async (ev) => {
     ev.preventDefault()
 
     await mutate({
@@ -117,60 +94,7 @@ export function ChangeRepositoryForm({ appName, repository, refetch, sharedSecre
               )}
             </form>
             {!isLoading && isSuccess && (
-              <>
-                <Typography variant="body_short_bold">Move the Deploy Key to the new repository</Typography>
-                <div className="o-body-text grid grid--gap-medium">
-                  <List variant="numbered">
-                    <List.Item>
-                      Open the <ExternalLink href={`${repository}/settings/keys`}>Deploy Key page</ExternalLink> to
-                      delete the Deploy Key from the previous repository
-                    </List.Item>
-                    <List.Item>
-                      Open the <ExternalLink href={`${repository}/settings/keys/new`}>Add New Deploy Key</ExternalLink>{' '}
-                      and follow the steps below
-                    </List.Item>
-                  </List>
-                  <img alt="'Add deploy key' steps on GitHub" src={imageDeployKey} srcSet={`${imageDeployKey} 2x`} />
-                  <List variant="numbered" start="3">
-                    <List.Item>Give the key a name, e.g. "Radix deploy key"</List.Item>
-                    <List.Item>Copy and paste this key:</List.Item>
-                  </List>
-                  <DeployKey appName={appName} />
-                  <List variant="numbered" start="5">
-                    <List.Item>Press "Add key"</List.Item>
-                  </List>
-                </div>
-                <Typography variant="body_short_bold">Move the Webhook to the new repository</Typography>
-                <div className="o-body-text">
-                  <List variant="numbered" start="6">
-                    <List.Item>
-                      Open the <ExternalLink href={`${repository}/settings/hooks`}>Webhook page</ExternalLink> of the
-                      previous repository and delete the existing Webhook
-                    </List.Item>
-                    <List.Item>
-                      Open the <ExternalLink href={`${repository}/settings/hooks/new`}>Add Webhook page</ExternalLink>{' '}
-                      and follow the steps below
-                    </List.Item>
-                  </List>
-                  <img alt="'Add webhook' steps on GitHub" src={imageWebhook} srcSet={`${imageWebhook} 2x`} />
-                  <List variant="numbered" start="8">
-                    <List.Item>
-                      As Payload URL, use <code>{webhookURL}</code> <CompactCopyButton content={webhookURL} />
-                    </List.Item>
-                    <List.Item>
-                      Choose <code>application/json</code> as Content type
-                    </List.Item>
-                    <List.Item>
-                      The Shared Secret for this application is{' '}
-                      <code style={{ verticalAlign: 'middle', minWidth: '10em', minHeight: '1.5em' }}>
-                        {sharedSecret}
-                      </code>{' '}
-                      <CompactCopyButton content={sharedSecret ?? ''} />
-                    </List.Item>
-                    <List.Item>Press "Add webhook"</List.Item>
-                  </List>
-                </div>
-              </>
+              <Alert type="success">Success: Remember to update your deploy key and your webhooks shared secret</Alert>
             )}
           </div>
         </Accordion.Panel>

--- a/src/pages/configuration/components/ChangeRepositoryForm.tsx
+++ b/src/pages/configuration/components/ChangeRepositoryForm.tsx
@@ -29,7 +29,7 @@ interface Props {
   appName: string
   repository: string
   refetch: () => unknown
-  sharedSecret: string
+  sharedSecret?: string
 }
 export function ChangeRepositoryForm({ appName, repository, refetch, sharedSecret }: Props) {
   const [currentRepository, setCurrentRepository] = useState(repository)
@@ -165,7 +165,7 @@ export function ChangeRepositoryForm({ appName, repository, refetch, sharedSecre
                       <code style={{ verticalAlign: 'middle', minWidth: '10em', minHeight: '1.5em' }}>
                         {sharedSecret}
                       </code>{' '}
-                      <CompactCopyButton content={sharedSecret} />
+                      <CompactCopyButton content={sharedSecret ?? ''} />
                     </List.Item>
                     <List.Item>Press "Add webhook"</List.Item>
                   </List>

--- a/src/store/radix-api.ts
+++ b/src/store/radix-api.ts
@@ -319,6 +319,7 @@ const injectedRtkApi = api.injectEndpoints({
         params: {
           sinceTime: queryArg.sinceTime,
           lines: queryArg.lines,
+          previous: queryArg.previous,
           file: queryArg.file,
           follow: queryArg.follow,
         },
@@ -1011,7 +1012,6 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/applications/${queryArg.appName}/regenerate-shared-secret`,
         method: "POST",
-        body: queryArg.regenerateSharedSecretData,
         headers: {
           "Impersonate-User": queryArg["Impersonate-User"],
           "Impersonate-Group": queryArg["Impersonate-Group"],
@@ -1420,6 +1420,8 @@ export type GetOAuthPodLogApiArg = {
   sinceTime?: string;
   /** Get log lines (example 1000) */
   lines?: string;
+  /** Get previous container log if true */
+  previous?: string;
   /** Get log as a file if true */
   file?: string;
   /** Get log as a server-sent event stream if true */
@@ -2300,8 +2302,6 @@ export type RegenerateSharedSecretApiArg = {
   "Impersonate-User"?: string;
   /** Works only with custom setup of cluster. Allow impersonation of a comma-separated list of test groups (Required if Impersonate-User is set) */
   "Impersonate-Group"?: string;
-  /** Regenerate shared secret and secret data */
-  regenerateSharedSecretData: RegenerateSharedSecretData;
 };
 export type ResetManuallyScaledComponentsInApplicationApiResponse = unknown;
 export type ResetManuallyScaledComponentsInApplicationApiArg = {
@@ -2559,6 +2559,9 @@ export type Component = {
   image: string;
   /** Name the component */
   name: string;
+  /** NextRun is the next time the job component's cron schedule is due to run, if a cron schedule is configured.
+    It is the earliest next run across all configured schedules, interpreted in the configured timezone and returned as a UTC timestamp. */
+  nextRun?: string;
   notifications?: Notifications;
   oauth2?: OAuth2AuxiliaryResource;
   /** Ports defines the port number and protocol that a component is exposed for internally in environment */
@@ -2831,8 +2834,6 @@ export type ApplicationRegistration = {
   readerAdUsers: string[];
   /** Repository the github repository */
   repository: string;
-  /** SharedSecret the shared secret of the webhook */
-  sharedSecret: string;
 };
 export type ApplicationRegistrationUpsertResponse = {
   applicationRegistration?: ApplicationRegistration;
@@ -3099,6 +3100,8 @@ export type ScheduledJobSummary = {
   command?: string[];
   /** Created timestamp */
   created?: string;
+  /** CronSchedule is the cron schedule expression, if this job was created by a cron schedule. */
+  cronSchedule?: string;
   /** DeploymentName name of RadixDeployment for the job */
   deploymentName: string;
   /** Ended timestamp */
@@ -3572,10 +3575,6 @@ export type ImageHubSecret = {
 export type RegenerateDeployKeyData = {
   /** PrivateKey of the deploy key */
   privateKey?: string;
-};
-export type RegenerateSharedSecretData = {
-  /** SharedSecret of the shared secret */
-  sharedSecret?: string;
 };
 export type ClusterConfigurationHoldsClusterConfigurationEnvironment = {
   /** ClusterEgressIps List of egress IPs for the cluster. Can be used for whitelisting in external services. */

--- a/src/style/settings.color.css
+++ b/src/style/settings.color.css
@@ -158,6 +158,14 @@
   --temp-eds-2-color-info-2: #f4ffff;
   --temp-eds-2-color-info-7: #6fb6e9;
   --temp-eds-2-color-info-12: #015e8d;
+
+  --temp-eds-2-color-success-2: #f6fff5;
+  --temp-eds-2-color-success-7: #7cc278;
+  --temp-eds-2-color-success-12: #20691f;
+
+  --temp-eds-2-color-danger-2: #fff9f8;
+  --temp-eds-2-color-danger-7: #ff7a7d;
+  --temp-eds-2-color-danger-12: #a50827;
 }
 
 .cluster-type--playground:root {


### PR DESCRIPTION
Eliminate the shared secret from the configuration and adjust the logic for regenerating the shared secret accordingly. This enhances security by removing sensitive information from the configuration.